### PR TITLE
CH1706: The "agent typing" gif appears on the wrong side of the chat

### DIFF
--- a/packages/deskpro-messenger/src/components/chat/TypingMessage.jsx
+++ b/packages/deskpro-messenger/src/components/chat/TypingMessage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const TypingMessage = ({ value }) => (
   <div className="dpmsg-MessageBubble">
-    <div className="dpmsg-MessageBubbleRow is-outgoing">
+    <div className="dpmsg-MessageBubbleRow is-incoming">
       {!!value.avatar && (
         <div className="dpmsg-AvatarCol is-rounded">
           <img src={value.avatar} alt={value.name} />


### PR DESCRIPTION
fix is-typing message appears to the right instead of left
---
https://app.clubhouse.io/deskpro/story/1706/the-agent-typing-gif-appears-on-the-wrong-side-of-the-chat