### PR TITLE
DPHC-328 - Add translatable phrase for "Subject" on ticket form in Messenger widget

### DIFF
--- a/packages/deskpro-messenger/src/components/chat/SaveTicketForm.jsx
+++ b/packages/deskpro-messenger/src/components/chat/SaveTicketForm.jsx
@@ -18,6 +18,10 @@ const transMessages = {
     id: 'helpcenter.messenger.tickets_form_email',
     defaultMessage: 'Email',
   },
+  subject: {
+    id: 'helpcenter.widget.tickets_form_label_subject',
+    defaultMessage: 'Subject',
+  },
   department: {
     id: 'helpcenter.general.department',
     defaultMessage: 'Department',
@@ -112,6 +116,7 @@ class SaveTicketForm extends PureComponent {
         email:         intl.formatMessage(transMessages.email),
         department:    intl.formatMessage(transMessages.department),
         message:       intl.formatMessage(transMessages.message),
+        subject:       intl.formatMessage(transMessages.subject),
         product:       intl.formatMessage(transMessages.product),
         priority:      intl.formatMessage(transMessages.priority),
         category:      intl.formatMessage(transMessages.category),

--- a/packages/deskpro-messenger/src/screens/StartChatScreen.jsx
+++ b/packages/deskpro-messenger/src/screens/StartChatScreen.jsx
@@ -39,6 +39,10 @@ const transMessages = {
     id:             'helpcenter.messenger.tickets_form_email',
     defaultMessage: 'Email',
   },
+  subject:           {
+    id:             'helpcenter.widget.tickets_form_label_subject',
+    defaultMessage: 'Subject',
+  }, 
   department:         {
     id:             'helpcenter.general.department',
     defaultMessage: 'Department',
@@ -232,6 +236,7 @@ class StartChatScreen extends PureComponent {
                     name:          intl.formatMessage(transMessages.name),
                     email:         intl.formatMessage(transMessages.email),
                     department:    intl.formatMessage(transMessages.department),
+                    subject:       intl.formatMessage(transMessages.subject),
                     message:       intl.formatMessage(transMessages.message),
                     product:       intl.formatMessage(transMessages.product),
                     priority:      intl.formatMessage(transMessages.priority),

--- a/packages/deskpro-messenger/src/screens/TicketFormScreen.jsx
+++ b/packages/deskpro-messenger/src/screens/TicketFormScreen.jsx
@@ -35,6 +35,10 @@ const transMessages = {
     id: 'helpcenter.general.department',
     defaultMessage: 'Department',
   },
+  subject: {
+    id: 'helpcenter.widget.tickets_form_label_subject',
+    defaultMessage: 'Subject',
+  },
   message: {
     id: 'helpcenter.messenger.tickets_form_message',
     defaultMessage: 'Message',
@@ -210,6 +214,7 @@ class TicketFormScreen extends React.Component {
                   name:          intl.formatMessage(transMessages.name),
                   email:         intl.formatMessage(transMessages.email),
                   department:    intl.formatMessage(transMessages.department),
+                  subject:       intl.formatMessage(transMessages.subject),                  
                   message:       intl.formatMessage(transMessages.message),
                   product:       intl.formatMessage(transMessages.product),
                   priority:      intl.formatMessage(transMessages.priority),

--- a/packages/deskpro-messenger/src/translations/en.json
+++ b/packages/deskpro-messenger/src/translations/en.json
@@ -78,5 +78,6 @@
   "helpcenter.messenger.tickets_form_submit": "Submit",
   "helpcenter.messenger.tickets_form_submit_button": "Save Ticket",
   "helpcenter.messenger.tickets_form_thanks": "Thank you for contacting us. One of our team will be in touch with you via email.",
-  "helpcenter.messenger.tickets_form_thanks_header": "Your request on its way"
+  "helpcenter.messenger.tickets_form_thanks_header": "Your request on its way",
+  "helpcenter.widget.tickets_form_label_subject": "Subject"
 }

--- a/packages/deskpro-messenger/src/translations/fr.json
+++ b/packages/deskpro-messenger/src/translations/fr.json
@@ -13,5 +13,6 @@
   "helpcenter.messenger.tickets_form_chooseAFile": "Choisir un fichier",
   "helpcenter.messenger.tickets_form_chooseFiles": "Choisir des fichiers",
   "helpcenter.messenger.tickets_form_select": "Choise",
-  "helpcenter.messenger.tickets_form_back": "Retour"
+  "helpcenter.messenger.tickets_form_back": "Retour",
+  "helpcenter.widget.tickets_form_label_subject": "Soumettre à"
 }


### PR DESCRIPTION
Cu Link: https://app.clickup.com/t/2583850/DPHC-328

Related PR: 
- https://github.com/deskpro/deskpro/pull/5783
- https://github.com/deskpro/portal-components/pull/48
