### PR TITLE
[SC-72604]: When messenger widget is embedded on external website, there is duplicate browser history

### DIFF
--- a/packages/deskpro-messenger/src/App.jsx
+++ b/packages/deskpro-messenger/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { createBrowserHistory as createHistory } from 'history';
+import { createMemoryHistory as createHistory } from 'history';
 import { MemoryRouter, Router } from 'react-router-dom';
 
 import Main from './containers/Main';

--- a/packages/deskpro-messenger/src/modules/app.js
+++ b/packages/deskpro-messenger/src/modules/app.js
@@ -2,7 +2,7 @@ import { combineEpics, ofType } from 'redux-observable';
 import { skip, map, take, tap, withLatestFrom } from 'rxjs/operators';
 import { produce } from 'immer';
 import isMobile from 'is-mobile';
-import { hasAgentsAvailable, canUseChat, canUseTickets } from './info';
+import {hasAgentsAvailable, canUseChat, canUseTickets, LOAD_APP_INFO_SUCCESS} from './info';
 
 import { SET_VISITOR } from './guest';
 import { CHAT_OPENED } from './chat';
@@ -44,7 +44,7 @@ export const setMessageFormFocus = (payload) => ({
 //#region EPICS
 const startupRedirectEpic = (action$, state$, { history, config, cache }) =>
   action$.pipe(
-    ofType(SET_VISITOR),
+    ofType(LOAD_APP_INFO_SUCCESS),
     take(1),
     withLatestFrom(state$),
     tap(([payload, state]) => {


### PR DESCRIPTION
Restore MemoryHistory (we're keeping locations in the cache anyway, and don't relay on it for pro-active chat now)