### PR TITLE
[sc-136982] Handle document.hidden status when gathering ACK messages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.5.1",
+  "version": "0.5.2",
   "npmClient": "yarn"
 }

--- a/packages/deskpro-messenger/package.json
+++ b/packages/deskpro-messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/messenger",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "DeskPRO <support@deskpro.com>",
   "license": "LicenseRef-LICENSE",
   "description": "DeskPRO embeddable messenger",

--- a/packages/deskpro-messenger/src/components/chat/Chat.jsx
+++ b/packages/deskpro-messenger/src/components/chat/Chat.jsx
@@ -137,11 +137,13 @@ class Chat extends React.Component {
     }
 
     if(this.messagesToAck.length) {
-      this.props.sendAck(this.messagesToAck, this.props.chat);
-
       this.messagesToAckTop = this.messagesToAckTop.filter(messageId => !this.messagesToAck.includes(messageId));
       this.messagesToAckBottom = this.messagesToAckBottom.filter(messageId => !this.messagesToAck.includes(messageId));
-      this.messagesToAck = [];
+
+      if (!document.hidden) {
+        this.props.sendAck(this.messagesToAck, this.props.chat);
+        this.messagesToAck = [];
+      }
     }
   }
 


### PR DESCRIPTION
https://app.shortcut.com/deskpro/story/136982/chat-message-marked-as-read-by-user-in-agent-ui-even-if-users-haven-t-seen-read-message